### PR TITLE
Steam Cloud Fix

### DIFF
--- a/LoreTracker/LoreTrackerStorage.cs
+++ b/LoreTracker/LoreTrackerStorage.cs
@@ -12,17 +12,21 @@ public class LoreTrackerStorageData
 
 public static class LoreTrackerStorage
 {
-    private const string SaveFileName = "LoreTrackerData.json";
+    private const string SaveFileName = "LoreTrackerData.owsave";
+    private const string OldSaveFileName = "LoreTrackerData.json";
 
     private static LoreTrackerStorageData _data;
     private static string CurrentProfile => StandaloneProfileManager.SharedInstance.currentProfile.profileName;
 
     private static string SaveFilePath =>
         Path.Combine(StandaloneProfileManager.SharedInstance._profilesPath, CurrentProfile, SaveFileName);
+    private static string OldSaveFilePath =>
+        Path.Combine(StandaloneProfileManager.SharedInstance._profilesPath, CurrentProfile, OldSaveFileName);
 
     public static void Load()
     {
         _data = JsonHelper.LoadJsonObject<LoreTrackerStorageData>(SaveFilePath)
+                ?? JsonHelper.LoadJsonObject<LoreTrackerStorageData>(OldSaveFilePath)
                 ?? new LoreTrackerStorageData();
         LoreTracker.I.ModHelper.Console.WriteLine("Loaded LoreTracker data", MessageType.Success);
     }


### PR DESCRIPTION
On steam, the game uses Steam Auto-Cloud to synchronize game progress. The configuration of what steam uploads is not stored locally, so we can't modify that. With a bit of experimentation we can however determine that (at the time of writing) it is configured to upload all files in the profile that end in `.owsave`. We can take advantage of that and just rename the mod save file from `.json` to `.owsave`. (The actual game save files are is just json files with other extensions as well anyway.)

To verify this works, the steam cloud contents can be viewed [here](https://store.steampowered.com/account/remotestorageapp/?appid=753640).